### PR TITLE
gRPC client factory integration

### DIFF
--- a/source/Dgraph.tests.e2e/Dgraph.tests.e2e.csproj
+++ b/source/Dgraph.tests.e2e/Dgraph.tests.e2e.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Assent" Version="1.4.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="FluentResults" Version="1.4.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.27.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
@@ -37,6 +38,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Tests/Data/*" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/source/Dgraph.tests.e2e/Orchestration/DgraphClientFactory.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/DgraphClientFactory.cs
@@ -6,7 +6,7 @@ using Serilog;
 
 namespace Dgraph.tests.e2e.Orchestration
 {
-    public class DgraphClientFactory {
+    public class DgraphClientFactory : IDgraphClientFactory {
 
         private bool printed;
 

--- a/source/Dgraph.tests.e2e/Orchestration/IDgraphClientFactory.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/IDgraphClientFactory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dgraph.tests.e2e.Orchestration
+{
+    public interface IDgraphClientFactory
+    {
+        Task<IDgraphClient> GetDgraphClient();
+    }
+}

--- a/source/Dgraph.tests.e2e/Orchestration/InjectedDgraphClientFactory.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/InjectedDgraphClientFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using Serilog;
+
+namespace Dgraph.tests.e2e.Orchestration
+{
+    class InjectedDgraphClientFactory : IDgraphClientFactory
+    {
+        private bool printed;
+
+        private readonly IServiceProvider provider;
+
+        public InjectedDgraphClientFactory(IServiceProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public async Task<IDgraphClient> GetDgraphClient()
+        {
+            AppContext.SetSwitch(
+                "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+            DgraphClient client = (DgraphClient)provider.GetService(typeof(DgraphClient));
+
+            if (!printed)
+            {
+                var result = await client.CheckVersion();
+                if (result.IsSuccess)
+                {
+                    Log.Information("Connected to Dgraph version {Version}", result.Value);
+                }
+                else
+                {
+                    Log.Information("Failed to get Dgraph version {Error}", result);
+                }
+                printed = true;
+            }
+
+            return client;
+        }
+
+    }
+}

--- a/source/Dgraph.tests.e2e/Orchestration/TestExecutor.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/TestExecutor.cs
@@ -11,9 +11,9 @@ namespace Dgraph.tests.e2e.Orchestration
         private List<Exception> _Exceptions = new List<Exception>();
 
         private readonly TestFinder TestFinder;
-        private readonly DgraphClientFactory ClientFactory;
+        private readonly IDgraphClientFactory ClientFactory;
 
-        public TestExecutor(TestFinder testFinder, DgraphClientFactory clientFactory) {
+        public TestExecutor(TestFinder testFinder, IDgraphClientFactory clientFactory) {
             TestFinder = testFinder;
             ClientFactory = clientFactory;
         }

--- a/source/Dgraph.tests.e2e/Tests/DgraphDotNetE2ETest.cs
+++ b/source/Dgraph.tests.e2e/Tests/DgraphDotNetE2ETest.cs
@@ -10,13 +10,13 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Dgraph.tests.e2e.Tests {
     public abstract class DgraphDotNetE2ETest {
-        protected readonly DgraphClientFactory ClientFactory;
+        protected readonly IDgraphClientFactory ClientFactory;
 
         protected readonly Assent.Configuration AssentConfiguration;
 
         private readonly IFileProvider EmbeddedProvider;
 
-        public DgraphDotNetE2ETest(DgraphClientFactory clientFactory) {
+        public DgraphDotNetE2ETest(IDgraphClientFactory clientFactory) {
             ClientFactory = clientFactory;
 
             AssentConfiguration = new Assent.Configuration()

--- a/source/Dgraph.tests.e2e/Tests/MutateQueryTest.cs
+++ b/source/Dgraph.tests.e2e/Tests/MutateQueryTest.cs
@@ -15,7 +15,7 @@ namespace Dgraph.tests.e2e.Tests
 
         private Person Person1, Person2, Person3;
 
-        public MutateQueryTest(DgraphClientFactory clientFactory) : base(clientFactory) { }
+        public MutateQueryTest(IDgraphClientFactory clientFactory) : base(clientFactory) { }
 
         public async override Task Setup() {
             await base.Setup();

--- a/source/Dgraph.tests.e2e/Tests/SchemaTest.cs
+++ b/source/Dgraph.tests.e2e/Tests/SchemaTest.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Dgraph.tests.e2e.Tests
 {
     public class SchemaTest : DgraphDotNetE2ETest {
-        public SchemaTest(DgraphClientFactory clientFactory) : base(clientFactory) { }
+        public SchemaTest(IDgraphClientFactory clientFactory) : base(clientFactory) { }
 
         public async override Task Test() {
             using(var client = await ClientFactory.GetDgraphClient()) {

--- a/source/Dgraph.tests.e2e/Tests/TransactionTest.cs
+++ b/source/Dgraph.tests.e2e/Tests/TransactionTest.cs
@@ -18,7 +18,7 @@ namespace Dgraph.tests.e2e.Tests
 
     public class TransactionTest : DgraphDotNetE2ETest {
 
-        public TransactionTest(DgraphClientFactory clientFactory) : base(clientFactory) { }
+        public TransactionTest(IDgraphClientFactory clientFactory) : base(clientFactory) { }
 
         public async override Task Setup() {
             await base.Setup();

--- a/source/Dgraph/Client/DgraphClient.cs
+++ b/source/Dgraph/Client/DgraphClient.cs
@@ -43,6 +43,11 @@ namespace Dgraph {
             }
         }
 
+        public DgraphClient(Api.Dgraph.DgraphClient client)
+        {
+            dgraphs.Add(client);
+        }
+
         // 
         // ------------------------------------------------------
         //              Transactions


### PR DESCRIPTION
Currently the `DgraphClient` class only exposes a constructor accepting gRPC channels, which will then be used to create the gRPC clients. These channels have to be manually mantained (lifetime, etc.) which may lead to misuses (e.g. gRPC channels should not be created for each new request but rather reused, see [docs](https://docs.microsoft.com/en-us/aspnet/core/grpc/client)).

Using the [gRPC client factory integration](https://docs.microsoft.com/en-us/aspnet/core/grpc/clientfactory) is an alternative approach to outsource the maintenance of the channel respectively the client. To use this approach, the `DgraphClient` class must accept the gRPC client directly rather than channels.

The current implementation does add the client from the constructor to the list of clients which are subject to the (currently not active) dispose logic. This should not be a problem, as the logic is currently inactive, but in the future this might be an issue, as the client's lifetime management should be managed by the client factory. I personally would also remove the inactive dispose logic and leave the channel lifetime management to the caller of the `DgraphClient`.