### PR TITLE
v23.0.0 Update & Clean PR #3: Update test projects and examples

### DIFF
--- a/examples/DgraphExample/DgraphExample.csproj
+++ b/examples/DgraphExample/DgraphExample.csproj
@@ -4,13 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.22.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.2" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
     <ProjectReference Include="..\..\source\Dgraph\Dgraph.csproj" />
   </ItemGroup>
 

--- a/examples/DgraphExample/ExecuteDQLQuery.cs
+++ b/examples/DgraphExample/ExecuteDQLQuery.cs
@@ -5,7 +5,7 @@ namespace DgraphExample
 {
     class ExecuteDQL
     {
-        public static async Task<string> Query(DgraphClient Client, string query)
+        public static async Task<string> Query(IDgraphClient Client, string query)
         {
             using (ITransaction transaction = Client.NewTransaction())
             {

--- a/examples/DgraphExample/Program.cs
+++ b/examples/DgraphExample/Program.cs
@@ -9,7 +9,7 @@ namespace DgraphExample
             // Connect to Dgraph Cloud.
             var cloudUrl = "https://green-bird.grpc.us-east-1.aws.cloud.dgraph.io/graphql";
             var APIKEY = "xxx=";
-            using var client = new DgraphClient(DgraphCloudChannel.Create(cloudUrl, APIKEY));
+            using var client = DgraphClient.Create(DgraphCloudChannel.Create(cloudUrl, APIKEY));
 
             var version = await client.CheckVersion();
 
@@ -26,6 +26,5 @@ namespace DgraphExample
             Console.WriteLine(result);
 
         }
-
     }
 }

--- a/source/Dgraph.tests.e2e/Dgraph.tests.e2e.csproj
+++ b/source/Dgraph.tests.e2e/Dgraph.tests.e2e.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Dgraph.tests.e2e</RootNamespace>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -12,30 +11,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Assent" Version="1.4.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="FluentResults" Version="1.4.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.55.0" />
+    <PackageReference Include="Assent" Version="2.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentResults" Version="3.15.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.2" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.8" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Dgraph\Dgraph.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Update="appsettings.json">
+    <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Tests/Data/*" CopyToOutputDirectory="Always" />

--- a/source/Dgraph.tests.e2e/Errors/DgraphDotNetTestFailure.cs
+++ b/source/Dgraph.tests.e2e/Errors/DgraphDotNetTestFailure.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System;
 using FluentResults;
 
 namespace Dgraph.tests.e2e.Errors

--- a/source/Dgraph.tests.e2e/Orchestration/DgraphClientFactory.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/DgraphClientFactory.cs
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using System;
-using System.Threading.Tasks;
-using Grpc.Core;
+
 using Grpc.Net.Client;
 using Serilog;
 
@@ -24,18 +21,16 @@ namespace Dgraph.tests.e2e.Orchestration
 {
     public class DgraphClientFactory
     {
-
         private bool printed;
 
         public async Task<IDgraphClient> GetDgraphClient()
         {
-
             // FIXME: This is not what you'd want to do in a real app.  Normally, there
             // would be tls to the server.  TO ADD - tests of running over https, and
             // with a Dgraph tls client certificate, and in enterprise mode.
             AppContext.SetSwitch(
                 "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-            var client = new DgraphClient(GrpcChannel.ForAddress("http://127.0.0.1:9080"));
+            var client = DgraphClient.Create(GrpcChannel.ForAddress("http://127.0.0.1:9080"));
 
             if (!printed)
             {
@@ -53,6 +48,5 @@ namespace Dgraph.tests.e2e.Orchestration
 
             return client;
         }
-
     }
 }

--- a/source/Dgraph.tests.e2e/Orchestration/TestExecutor.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/TestExecutor.cs
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Dgraph.tests.e2e.Orchestration
 {

--- a/source/Dgraph.tests.e2e/Orchestration/TestFinder.cs
+++ b/source/Dgraph.tests.e2e/Orchestration/TestFinder.cs
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+
 using Dgraph.tests.e2e.Tests;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/source/Dgraph.tests.e2e/Program.cs
+++ b/source/Dgraph.tests.e2e/Program.cs
@@ -13,12 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+
 using Dgraph.tests.e2e.Errors;
 using Dgraph.tests.e2e.Orchestration;
 using Dgraph.tests.e2e.Tests;
@@ -29,7 +24,6 @@ using Serilog;
 
 namespace Dgraph.tests.e2e
 {
-
     [Command(Name = "Dgraph.net E2E test runner")]
     [HelpOption("--help")]
     class Program

--- a/source/Dgraph.tests.e2e/Tests/Approved/SchemaTest.AlterSchemAsExpected.approved.txt
+++ b/source/Dgraph.tests.e2e/Tests/Approved/SchemaTest.AlterSchemAsExpected.approved.txt
@@ -1,5 +1,8 @@
 abool: bool .
+dgraph.drop.op: string .
+dgraph.graphql.p_query: string @index(sha256) .
 dgraph.graphql.schema: string .
+dgraph.graphql.xid: string @index(exact) @upsert .
 dgraph.type: [string] @index(exact) .
 dob: datetime @index(year) .
 friends: [uid] @reverse @count .
@@ -17,4 +20,9 @@ type Person {
 
 type dgraph.graphql {
 	dgraph.graphql.schema
+	dgraph.graphql.xid
+}
+
+type dgraph.graphql.persisted_query {
+	dgraph.graphql.p_query
 }

--- a/source/Dgraph.tests.e2e/Tests/Approved/SchemaTest.AlterSchemaAgainAsExpected.approved.txt
+++ b/source/Dgraph.tests.e2e/Tests/Approved/SchemaTest.AlterSchemaAgainAsExpected.approved.txt
@@ -1,7 +1,10 @@
 abool: bool .
 car: uid @count .
 carMake: string @index(hash) .
+dgraph.drop.op: string .
+dgraph.graphql.p_query: string @index(sha256) .
 dgraph.graphql.schema: string .
+dgraph.graphql.xid: string @index(exact) @upsert .
 dgraph.type: [string] @index(exact) .
 dob: datetime @index(day) .
 friends: [uid] @reverse @count .
@@ -19,4 +22,9 @@ type Person {
 
 type dgraph.graphql {
 	dgraph.graphql.schema
+	dgraph.graphql.xid
+}
+
+type dgraph.graphql.persisted_query {
+	dgraph.graphql.p_query
 }

--- a/source/Dgraph.tests.e2e/Tests/Approved/SchemaTest.InitialSchemaIsAsExpected.approved.txt
+++ b/source/Dgraph.tests.e2e/Tests/Approved/SchemaTest.InitialSchemaIsAsExpected.approved.txt
@@ -1,5 +1,13 @@
+dgraph.drop.op: string .
+dgraph.graphql.p_query: string @index(sha256) .
 dgraph.graphql.schema: string .
+dgraph.graphql.xid: string @index(exact) @upsert .
 dgraph.type: [string] @index(exact) .
 type dgraph.graphql {
 	dgraph.graphql.schema
+	dgraph.graphql.xid
+}
+
+type dgraph.graphql.persisted_query {
+	dgraph.graphql.p_query
 }

--- a/source/Dgraph.tests.e2e/Tests/DgraphDotNetE2ETest.cs
+++ b/source/Dgraph.tests.e2e/Tests/DgraphDotNetE2ETest.cs
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-using System.IO;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using Assent.Namers;
 using Dgraph.tests.e2e.Errors;
 using Dgraph.tests.e2e.Orchestration;
 using FluentResults;
 using Microsoft.Extensions.FileProviders;
+using Serilog;
 
 namespace Dgraph.tests.e2e.Tests
 {
@@ -39,7 +38,11 @@ namespace Dgraph.tests.e2e.Tests
             ClientFactory = clientFactory;
 
             AssentConfiguration = new Assent.Configuration()
-                .UsingNamer(new SubdirectoryNamer("Approved"));
+                .UsingNamer(new SubdirectoryNamer("Approved"))
+                .UsingReporter((received, approved) =>
+                {
+                    Log.Warning("Expected {received}, got {approved}", received, approved);
+                });
             // FIXME: .UsingSanitiser(...) might want to add this to remove versions etc
             // FIXME: when I add this to a build pipeline it needs this turned off when running on the build server
             // .SetInteractive(...);

--- a/source/Dgraph.tests.e2e/Tests/DgraphDotNetE2ETest.cs
+++ b/source/Dgraph.tests.e2e/Tests/DgraphDotNetE2ETest.cs
@@ -41,7 +41,9 @@ namespace Dgraph.tests.e2e.Tests
                 .UsingNamer(new SubdirectoryNamer("Approved"))
                 .UsingReporter((received, approved) =>
                 {
-                    Log.Warning("Expected {received}, got {approved}", received, approved);
+                    received = System.IO.File.ReadAllText(received);
+                    approved = System.IO.File.ReadAllText(approved);
+                    Log.Warning("Expected:\n{approved}\nReceived:\n{received}\n", approved, received);
                 });
             // FIXME: .UsingSanitiser(...) might want to add this to remove versions etc
             // FIXME: when I add this to a build pipeline it needs this turned off when running on the build server

--- a/source/Dgraph.tests.e2e/Tests/SchemaTest.cs
+++ b/source/Dgraph.tests.e2e/Tests/SchemaTest.cs
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-using System.Threading.Tasks;
 using Assent;
 using Dgraph.tests.e2e.Orchestration;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Dgraph.Schema;
-using Api;
-using System;
-using System.Threading;
 
 namespace Dgraph.tests.e2e.Tests
 {
@@ -32,15 +28,14 @@ namespace Dgraph.tests.e2e.Tests
 
         public async override Task Test()
         {
-            using (var client = await ClientFactory.GetDgraphClient())
-            {
-                await InitialSchemaIsAsExpected(client);
-                await AlterSchemAsExpected(client);
-                await AlterSchemaAgainAsExpected(client);
-                await SchemaQueryWithRestrictions(client);
+            using var client = await ClientFactory.GetDgraphClient();
 
-                await ErrorsResultInFailedQuery(client);
-            }
+            await InitialSchemaIsAsExpected(client);
+            await AlterSchemAsExpected(client);
+            await AlterSchemaAgainAsExpected(client);
+            await SchemaQueryWithRestrictions(client);
+
+            await ErrorsResultInFailedQuery(client);
         }
 
         private async Task InitialSchemaIsAsExpected(IDgraphClient client)
@@ -55,7 +50,7 @@ namespace Dgraph.tests.e2e.Tests
         private async Task AlterSchemAsExpected(IDgraphClient client)
         {
             var alterSchemaResult = await client.Alter(
-                new Operation { Schema = ReadEmbeddedFile("test.schema") });
+                new Api.Operation { Schema = ReadEmbeddedFile("test.schema") });
             AssertResultIsSuccess(alterSchemaResult);
 
             // After an Alter, Dgraph computes indexes in the background.
@@ -75,7 +70,7 @@ namespace Dgraph.tests.e2e.Tests
         private async Task AlterSchemaAgainAsExpected(IDgraphClient client)
         {
             var alterSchemaResult = await client.Alter(
-                new Operation { Schema = ReadEmbeddedFile("altered.schema") });
+                new Api.Operation { Schema = ReadEmbeddedFile("altered.schema") });
             AssertResultIsSuccess(alterSchemaResult);
 
             Thread.Sleep(TimeSpan.FromSeconds(5));

--- a/source/Dgraph.tests.e2e/Tests/TestClasses/FriendQueries.cs
+++ b/source/Dgraph.tests.e2e/Tests/TestClasses/FriendQueries.cs
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using System.Collections.Generic;
+
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 
 namespace Dgraph.tests.e2e.Tests.TestClasses
 {
-
     public class FriendQueries
     {
-
         public static string QueryByUid(string uid) =>
             "{  "
             + $"    q(func: uid({uid})) "

--- a/source/Dgraph.tests.e2e/Tests/TestClasses/Person.cs
+++ b/source/Dgraph.tests.e2e/Tests/TestClasses/Person.cs
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using System;
-using System.Collections.Generic;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace Dgraph.tests.e2e.Tests.TestClasses
 {
-
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Person
     {
@@ -34,5 +31,4 @@ namespace Dgraph.tests.e2e.Tests.TestClasses
         public double Height { get; set; }
         public List<int> Scores { get; } = new List<int>();
     }
-
 }

--- a/source/Dgraph.tests/Dgraph.tests.csproj
+++ b/source/Dgraph.tests/Dgraph.tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.22.3" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.2" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Dgraph.tests/Transactions/BuilderFixture.cs
+++ b/source/Dgraph.tests/Transactions/BuilderFixture.cs
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-using Dgraph.Transactions;
+
 using FluentAssertions;
 using Google.Protobuf;
 using NUnit.Framework;
@@ -23,7 +22,6 @@ namespace Dgraph.tests.Transactions
 {
     public class BuilderFixture
     {
-
         [TestCase(null, null, null)]
         [TestCase("query", null, null)]
         [TestCase(null, true, null)]
@@ -35,11 +33,11 @@ namespace Dgraph.tests.Transactions
 
             if (query != null)
             {
-                builder.Query = query;
+                builder.WithQuery(query);
             }
             if (commit != null)
             {
-                builder.CommitNow = commit.Value;
+                builder.CommitNow(commit.Value);
             }
             if (withMutation)
             {
@@ -63,14 +61,14 @@ namespace Dgraph.tests.Transactions
 
             if (query != null)
             {
-                builder.Query = query;
+                builder.WithQuery(query);
             }
             if (commit != null)
             {
-                builder.CommitNow = commit.Value;
+                builder.CommitNow(commit.Value);
             }
 
-            var mb = new MutationBuilder() { SetJson = "json" };
+            var mb = new MutationBuilder().SetJson("json");
             if (withMutation)
             {
                 builder.WithMutations(mb);
@@ -108,14 +106,12 @@ namespace Dgraph.tests.Transactions
         )
         {
 
-            var mb = new MutationBuilder
-            {
-                SetJson = setJson,
-                SetNquads = setNQ,
-                DeleteJson = deleteJson,
-                DelNquads = deleteNQ,
-                Cond = cond
-            };
+            var mb = new MutationBuilder()
+                .SetJson(setJson)
+                .SetNquads(setNQ)
+                .DeleteJson(deleteJson)
+                .DelNquads(deleteNQ)
+                .Cond(cond);
 
             mb.Mutation.Should().Be(
                 new Api.Mutation

--- a/source/Dgraph.tests/Transactions/ClientFixture.cs
+++ b/source/Dgraph.tests/Transactions/ClientFixture.cs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 namespace Dgraph.tests.Transactions
 {
     public class ClientFixture

--- a/source/Dgraph.tests/Transactions/CommitFixture.cs
+++ b/source/Dgraph.tests/Transactions/CommitFixture.cs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -33,7 +33,7 @@ namespace Dgraph.tests.Transactions
         public async Task Commit_SetsTransactionStateToCommitted()
         {
             var client = Substitute.For<IDgraphClientInternal>();
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
             await txn.Commit();
 
             txn.TransactionState.Should().Be(TransactionState.Committed);
@@ -43,7 +43,7 @@ namespace Dgraph.tests.Transactions
         public async Task Commit_ClientNotReceiveCommitIfNoMutation()
         {
             var client = Substitute.For<IDgraphClientInternal>();
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
             await txn.Commit();
 
             await client.DidNotReceive().DgraphExecute(
@@ -56,11 +56,11 @@ namespace Dgraph.tests.Transactions
         {
             (var client, _) = MinimalClient();
 
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
 
             var req = new RequestBuilder().
-                WithMutations(new MutationBuilder { SetJson = "json" });
-            await txn.Mutate(req);
+                WithMutations(new MutationBuilder().SetJson("json"));
+            await txn.Do(req);
             await txn.Commit();
 
             // FIXME: can't really test what the Dgraph got without
@@ -75,16 +75,16 @@ namespace Dgraph.tests.Transactions
         {
             (var client, _) = MinimalClient();
 
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
 
             var req = new RequestBuilder().
-                WithMutations(new MutationBuilder { SetJson = "json" });
-            await txn.Mutate(req);
+                WithMutations(new MutationBuilder().SetJson("json"));
+            await txn.Do(req);
 
             client.DgraphExecute(
                 Arg.Any<Func<Api.Dgraph.DgraphClient, Task<Result>>>(),
                 Arg.Any<Func<RpcException, Result>>()).Returns(
-                    Results.Fail(new ExceptionalError(
+                    Result.Fail(new ExceptionalError(
                         new RpcException(new Status(), "Something failed"))));
             var result = await txn.Commit();
 

--- a/source/Dgraph.tests/Transactions/DiscardFixture.cs
+++ b/source/Dgraph.tests/Transactions/DiscardFixture.cs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -26,7 +26,6 @@ using NUnit.Framework;
 
 namespace Dgraph.tests.Transactions
 {
-
     public class DiscardFixture : TransactionFixtureBase
     {
 
@@ -34,7 +33,7 @@ namespace Dgraph.tests.Transactions
         public async Task Discard_SetsTransactionStateToAborted()
         {
             var client = Substitute.For<IDgraphClientInternal>();
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
             await txn.Discard();
 
             txn.TransactionState.Should().Be(TransactionState.Aborted);
@@ -44,7 +43,7 @@ namespace Dgraph.tests.Transactions
         public async Task Discard_ClientNotReceiveDiscardIfNoMutation()
         {
             var client = Substitute.For<IDgraphClientInternal>();
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
             await txn.Discard();
 
             await client.DidNotReceive().DgraphExecute(
@@ -57,11 +56,11 @@ namespace Dgraph.tests.Transactions
         {
             (var client, _) = MinimalClient();
 
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
 
             var req = new RequestBuilder().
-                WithMutations(new MutationBuilder { SetJson = "json" });
-            await txn.Mutate(req);
+                WithMutations(new MutationBuilder().SetJson("json"));
+            await txn.Do(req);
             await txn.Discard();
 
             await client.Received().DgraphExecute(
@@ -74,16 +73,16 @@ namespace Dgraph.tests.Transactions
         {
             (var client, _) = MinimalClient();
 
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
 
             var req = new RequestBuilder().
-                WithMutations(new MutationBuilder { SetJson = "json" });
-            await txn.Mutate(req);
+                WithMutations(new MutationBuilder().SetJson("json"));
+            await txn.Do(req);
 
             client.DgraphExecute(
                 Arg.Any<Func<Api.Dgraph.DgraphClient, Task<Result>>>(),
                 Arg.Any<Func<RpcException, Result>>()).Returns(
-                    Results.Fail(new ExceptionalError(new RpcException(new Status(), "Something failed"))));
+                    Result.Fail(new ExceptionalError(new RpcException(new Status(), "Something failed"))));
             var result = await txn.Discard();
 
             result.IsFailed.Should().BeTrue();

--- a/source/Dgraph.tests/Transactions/IQueryFixture.cs
+++ b/source/Dgraph.tests/Transactions/IQueryFixture.cs
@@ -45,7 +45,7 @@ namespace Dgraph.tests.Transactions
         public async Task Query_PassesBackResult()
         {
             (var client, var response) = MinimalClient();
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
 
             response.DgraphResponse.Json = ByteString.CopyFromUtf8("json");
             // ??ByteString.CopyFrom(Encoding.UTF8.GetBytes(json));
@@ -53,7 +53,7 @@ namespace Dgraph.tests.Transactions
             client.DgraphExecute(
                 Arg.Any<Func<Api.Dgraph.DgraphClient, Task<Result<Response>>>>(),
                 Arg.Any<Func<RpcException, Result<Response>>>()).Returns(
-                    Results.Ok(response));
+                    Result.Ok(response));
 
             var result = await txn.QueryWithVars(
                 "query",
@@ -70,9 +70,10 @@ namespace Dgraph.tests.Transactions
             client.DgraphExecute(
                 Arg.Any<Func<Api.Dgraph.DgraphClient, Task<Result<Response>>>>(),
                 Arg.Any<Func<RpcException, Result<Response>>>()).Returns(
-                    Results.Fail(new ExceptionalError(new RpcException(new Status(), "Something failed"))));
+                    Result.Fail(new ExceptionalError(new RpcException(new Status(), "Something failed"))));
 
-            var result = await (new Transaction(client)).Query("throw");
+            ITransaction txn = new Transaction(client);
+            var result = await txn.Query("throw");
 
             result.IsFailed.Should().Be(true);
             result.Errors.First().Should().BeOfType<ExceptionalError>();
@@ -86,9 +87,9 @@ namespace Dgraph.tests.Transactions
             client.DgraphExecute(
                 Arg.Any<Func<Api.Dgraph.DgraphClient, Task<Result<Response>>>>(),
                 Arg.Any<Func<RpcException, Result<Response>>>()).Returns(
-                    Results.Fail(new ExceptionalError(new RpcException(new Status(), "Something failed"))));
+                    Result.Fail(new ExceptionalError(new RpcException(new Status(), "Something failed"))));
 
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
             var result = await txn.Query("throw");
 
             txn.TransactionState.Should().Be(TransactionState.OK);
@@ -98,7 +99,7 @@ namespace Dgraph.tests.Transactions
         public async Task Query_SuccessDoesntChangeTransactionOKState()
         {
             (var client, var response) = MinimalClient();
-            var txn = new Transaction(client);
+            ITransaction txn = new Transaction(client);
 
             await txn.QueryWithVars(
                 "query",

--- a/source/Dgraph.tests/Transactions/TransactionFixtureBase.cs
+++ b/source/Dgraph.tests/Transactions/TransactionFixtureBase.cs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -26,7 +26,6 @@ namespace Dgraph.tests.Transactions
 {
     public class TransactionFixtureBase
     {
-
         internal (IDgraphClientInternal, Response) MinimalClient()
         {
             var client = Substitute.For<IDgraphClientInternal>();
@@ -36,15 +35,15 @@ namespace Dgraph.tests.Transactions
             var response = new Response(dgResp);
             client.DgraphExecute(
                 Arg.Any<Func<Api.Dgraph.DgraphClient, Task<Result<Response>>>>(),
-                Arg.Any<Func<RpcException, Result<Response>>>()).Returns(Results.Ok(response));
+                Arg.Any<Func<RpcException, Result<Response>>>()).Returns(Result.Ok(response));
 
             return (client, response);
         }
 
         protected List<Func<Task<ResultBase>>> GetAllTestFunctions(ITransaction txn) =>
             new List<Func<Task<ResultBase>>> {
-                async () => await txn.Mutate(new RequestBuilder().
-                    WithMutations(new MutationBuilder{ SetJson = "json" })),
+                async () => await txn.Do(new RequestBuilder().
+                    WithMutations(new MutationBuilder().SetJson("json"))),
                 async () => await txn.Query("query"),
                 async () => await txn.QueryWithVars("query", null),
                 async () => await txn.Commit()


### PR DESCRIPTION
Refactored unit tests, e2e tests, and examples to use the updated client & transaction interfaces. Otherwise there are no functional changes or additional tests added.

Some key file changes are in the `source/Dgraph.tests.e2e/Tests/Approved/` folder.  Please review these to confirm that the updated schemas are correct. The new schemas were updated by running their respective tests and copying the received output. It is possible that the client or the unit tests have bugs that I do not have the dgraph expertise to diagnose.